### PR TITLE
Unescape commas in contact names

### DIFF
--- a/heysms/lib/lib.py
+++ b/heysms/lib/lib.py
@@ -50,7 +50,7 @@ def search_contact_by_number(phone_number):
                     ret = tmp[0]
             break
 
-    ret = ret.decode('utf-8')
+    ret = ret.decode('utf-8').replace("\\,", ",")
 
     logger.debug("contact name: %s" % ret)
     return ret
@@ -64,7 +64,7 @@ def search_contacts(pattern):
             # not found
             continue
         if len(s.groups()) > 0:
-            name = s.groups()[0]
+            name = s.groups()[0].replace("\\,", ",")
             if name.lower().find(pattern.lower()) != -1:
                 numbers = re.findall("TEL;TYPE=.*?CELL.*?:(.[0-9]*)\r\n", contact)
                 for number in numbers:


### PR DESCRIPTION
The contact names in my address book are following the "Surname, Firstname" scheme.  As per RFC 2426 the name is escaped, i.e. the database stores "Surname\, Firstname".

HeySms simply takes the vCard and takes it apart using regular expressions, not handling the escaped comma however.  This results in a contact list (on the PC) showing backslashes, which is awkward.

Since there's no real use in leaving the escape signs in there I vote for removing them.

cheers
  stesie
