### PR TITLE
Fix upper (unused) nibble in destination phone number.

### DIFF
--- a/heysms/lib/lib_sms.py
+++ b/heysms/lib/lib_sms.py
@@ -228,7 +228,7 @@ def semi_octify(str):
             digit_2 = int(str[1])
             octet = (digit_2 << 4) | digit_1
         except:
-            octet = (1 << 4) | digit_1
+            octet = 0xF0 | digit_1
 
         return octet
 


### PR DESCRIPTION
according to the spec the unused nibble of the phone-number part of the PDU (in case of a number with an odd number of digits) should be F not 1 ... 

so most of the phones don't seem to care ...
