### PR TITLE
Send messages using GSM-7 alphabet if possible

### DIFF
--- a/heysms/lib/lib_sms.py
+++ b/heysms/lib/lib_sms.py
@@ -358,8 +358,8 @@ def createPDUmessage(number, msg):
 
 
         if DCS & 0x08:  # UCS-2 encoding
-            for i in xrange (len(msg)) :
-                digit = ord(msg[i])
+            for i in xrange (len(part)) :
+                digit = ord(part[i])
                 pdu_message.append(digit >> 8)
                 pdu_message.append(digit & 0xFF)
 

--- a/heysms/lib/lib_sms.py
+++ b/heysms/lib/lib_sms.py
@@ -6,6 +6,7 @@
 #    This file is part of HeySms
 #
 #    Copyright (C) 2012 Thibault Cohen
+#    Copyright (C) 2012 Stefan Siegl <stesie@brokenpipe.de>
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -178,20 +179,20 @@ def _decode_default_alphabet(s):
     return u_str.encode("utf-8")
 
 
-def octify(str):
+def octify(str, shift):
         '''
         Returns a list of octet bytes representing
         each char of the input str.
         '''
-        try:
-            bytes = map(GSM_DEFAULT_ALPHABET.index, str)
-            bytes = [b if b != 27 else 32 for b in bytes]
-        except ValueError, e:
-            bytes = map(ord, str)
+        bytes = map(GSM_DEFAULT_ALPHABET.index, str)
+        bytes = [b if b != 27 else 32 for b in bytes]
 
         bitsconsumed = 0
         referencebit = 7
         octets = []
+
+        for i in xrange(shift):
+                bytes.insert(0, 0)
 
         while len(bytes):
                 byte = bytes.pop(0)
@@ -205,14 +206,14 @@ def octify(str):
                     octet = (byte | 0x00)
 
                 if bitsconsumed != 7:
-                    octets.append(byte | bitstocopy)
+                    octets.append(octet)
                     bitsconsumed += 1
                     referencebit -= 1
                 else:
                     bitsconsumed = 0
                     referencebit = 7
 
-        return octets
+        return octets[shift - shift / 7:]
 
 
 def semi_octify(str):
@@ -271,7 +272,8 @@ def createPDUmessage(number, msg):
     '''
     Returns a list of bytes to represent a valid PDU message
     '''
-    #prepare for accentd
+
+    # Convert to Python Unicode string (prepare for accentd)
     msg = msg.decode('utf-8')
 
     # Unknown type, works with 514 xxx xxxx, 1 514 xxx xxxx
@@ -285,33 +287,41 @@ def createPDUmessage(number, msg):
         number = number[1:]
 
     numlength = len(number)
-
-    number_length = len(number)
-    if (numlength % 2) == 0:
-            rangelength = numlength
-    else:
+    if (numlength % 2):
             number = number + 'F'
-            rangelength = len(number)
 
     octifiednumber = [semi_octify(number[i:i + 2])
-                      for i in range(0, rangelength, 2)]
+                      for i in range(0, len(number), 2)]
 
     PDU_TYPE = 0x11 
     MR = 0
 
-    if len(msg) > 70:
-        logger.debug("Message length beyond 140 bytes, sending multiple SMSes")
+    # Test whether message can be represented in GSM-7 alphabet
+    try:
+        map(GSM_DEFAULT_ALPHABET.index, msg)
+        DCS = 0     # yes it can
+        need_chunking = len(msg) > 160
+        chunksize = 153
+
+    except ValueError:
+        # Message cannot be represented using GSM alphabet, use UCS-2
+        DCS = 8
+        need_chunking = len(msg) > 70
+        chunksize = 67
+
+    if need_chunking:
+        logger.debug("Message too long for one SMS")
         PDU_TYPE |= 0x40
-        chunks = int(ceil(1.0 * len(msg) / 67))
+        chunks = int(ceil(1.0 * len(msg) / chunksize))
         ref = randint(0, 255)
     else:
         chunks = 1
 
-    pdu_template = [PDU_TYPE, MR, number_length, ADDR_TYPE]
+    pdu_template = [PDU_TYPE, MR, numlength, ADDR_TYPE]
     pdu_template.extend(octifiednumber)
 
     pdu_template.append(0) #PID
-    pdu_template.append(8) #DCS
+    pdu_template.append(DCS) #DCS
 
     pdu_template.append(167) #VP 24 hours
 
@@ -321,8 +331,14 @@ def createPDUmessage(number, msg):
         pdu_message = copy(pdu_template)
 
         if PDU_TYPE & 0x40:
-            part = msg[chunk * 67 : (chunk + 1) * 67]
-            pdu_message.append(6 + 2 * len(part))  # length
+            part = msg[chunk * chunksize : (chunk + 1) * chunksize]
+
+            if DCS & 0x08:
+                # UCS-2 encoding, hence UDL in octets
+                pdu_message.append(6 + 2 * len(part))
+            else:
+                # GSM-7 encoding, UDL in septets
+                pdu_message.append(7 + len(part))
 
             # concatenated SMS header
             pdu_message.append(5)   # UDH length
@@ -333,12 +349,23 @@ def createPDUmessage(number, msg):
             pdu_message.append(1 + chunk)
         else:
             part = msg
-            pdu_message.append(len(part) * 2)
 
-        for i in xrange (len(part)) :
-            digit = ord(part[i])
-            pdu_message.append(digit >> 8)
-            pdu_message.append(digit & 0xFF)
+            if DCS & 0x08:
+                # UCS-2 encoding, hence UDL in octets (2 bytes per char)
+                pdu_message.append(2 * len(part))
+            else:
+                # GSM-7 encoding, UDL in septets
+                pdu_message.append(len(part))
+
+
+        if DCS & 0x08:  # UCS-2 encoding
+            for i in xrange (len(msg)) :
+                digit = ord(msg[i])
+                pdu_message.append(digit >> 8)
+                pdu_message.append(digit & 0xFF)
+
+        else:  # GSM-7 encoding
+            pdu_message.extend(octify(part, 7 if PDU_TYPE & 0x40 else 0))
 
         pdus.append(pdu_message)
 


### PR DESCRIPTION
hi again :-)

I've improved the PDU generation code to use the GSM-7 alphabet if possible.  This is, if the user provides a message consisting solely of characters that are available in the GSM-7 alphabet, that one is used.  In that very case a single SMS may consist of up to 160 chars.

If a message with Unicode-only chars is to be sent (e.g. one containing the Euro sign), then UCS-2 is used to encode the message into PDU format like before.  Then however a single SMS can only hold up to 70 chars.

Besides I've fixed the indentation in lib_sms.py.  The whole project seems to indent blocks by 4 extra spaces.  However in lib_sms.py there were some functions that added 8 spaces...

cheers,
  stesie
