### PR TITLE
Avahi force ipv4

### DIFF
--- a/heysms/lib/lib.py
+++ b/heysms/lib/lib.py
@@ -94,22 +94,6 @@ def resolve(name, interface):
         #print args[0]
         ml.quit()
 
-    def myhandler(interface, protocol, name, stype, domain, flags):
-        # print "Found service '%s' type '%s' domain '%s' " % (name,
-        #                                                      stype,
-        #                                                      domain)
-
-        print flags
-        print avahi.LOOKUP_RESULT_LOCAL
-        print 'WWWW'
-        if flags & avahi.LOOKUP_RESULT_LOCAL:
-                # local service, skip
-                ml.quit()
-
-        server.ResolveService(interface, protocol, name, stype,
-            domain, avahi.PROTO_UNSPEC, dbus.UInt32(0),
-            reply_handler=service_resolved, error_handler=print_error)
-
     loop = DBusGMainLoop()
 
     bus = dbus.SystemBus(mainloop=loop)

--- a/heysms/lib/lib.py
+++ b/heysms/lib/lib.py
@@ -122,7 +122,7 @@ def resolve(name, interface):
                           name,
                           '_presence._tcp',
                           'local',
-                          avahi.PROTO_UNSPEC,
+                          avahi.PROTO_INET,
                           dbus.UInt32(0),
                           reply_handler=service_resolved,
                           error_handler=print_error)


### PR DESCRIPTION
Hi again :-)

in heysms/lib/lib.py HeySms calls ResolveService function of the avahi daemon.  However it does _not_ specify a protocol filter.  If the N900 has an IPv6 address and the auth contact supports IPv6 also, avahi lists the presence twice (once for IPv4, once for IPv6).

If the IPv6 entry happens to be the first in the list, the `service_resolved` callback is triggered for that one.  However it requires a dot to be in the host address (which is not the case for IPv6 addresses).  `ret` is hence overwritten to `None` and passed forward, which of course causes problems later on.

I've limited the resolver to PROTO_INET, the IPv4 protocol.

Besides I've dropped `myhandler`.  I suppose it's debug code written down when testing initially.  At least it seems not used anywhere.

cheers,
  stesie
